### PR TITLE
Input - Inherit font family

### DIFF
--- a/src/atoms/StyleReset.js
+++ b/src/atoms/StyleReset.js
@@ -32,8 +32,8 @@ const StyleReset = createGlobalStyle`
   }
 
   input {
-    border: none;
     font-family: inherit;
+    border: none;
   }
 
   button {

--- a/src/atoms/StyleReset.js
+++ b/src/atoms/StyleReset.js
@@ -31,7 +31,10 @@ const StyleReset = createGlobalStyle`
     text-decoration: none;
   }
 
-  input { border: none }
+  input {
+    border: none;
+    font-family: inherit;
+  }
 
   button {
     border: none;


### PR DESCRIPTION
Currently input controls do not get the same font family as the rest of the page, eg:

![image](https://user-images.githubusercontent.com/10521775/62939594-8e995380-bdc9-11e9-8753-2785e795b28e.png)

Adding CSS rule to inherit the font family:

![image](https://user-images.githubusercontent.com/10521775/62939718-d029fe80-bdc9-11e9-8857-ea2bc8112b70.png)

