### PR TITLE
fix:  at currentDevice.js , changed currentWidth pararmeters for XL and LG screens support

### DIFF
--- a/src/functions/currentDevice.js
+++ b/src/functions/currentDevice.js
@@ -1,15 +1,15 @@
 const currentDevice = () => {
   const currentWidth = window.innerWidth;
   if (currentWidth < 576) {
-    return "xs";
+    return 'xs';
   } else if (currentWidth < 768) {
-    return "sm";
-  } else if (currentWidth < 992) {
-    return "md";
-  } else if (currentWidth < 992) {
-    return "lg";
-  } else if (1200 < currentWidth) {
-    return "xl";
+    return 'sm';
+  } else if (currentWidth < 960) {
+    return 'md';
+  } else if (currentWidth < 1280) {
+    return 'lg';
+  } else if (1900 < currentWidth) {
+    return 'xl';
   } else {
     return "Couldn't find device";
   }


### PR DESCRIPTION
Main reason for this Pull Request, is that actually its not possible to differentiate md,lg and xl screens, altough if THEME, or ThemeProvider are changed for proper width values, only worked after modifying this specific file