### PR TITLE
fix: device query max-width

### DIFF
--- a/src/style-functions/deviceQuerry.js
+++ b/src/style-functions/deviceQuerry.js
@@ -1,9 +1,9 @@
 const DEVICEQUERRY = {
-  xs: "@media screen and (min-width: 0px)",
-  sm: "@media screen and (min-width: 576px)",
-  md: "@media screen and (min-width: 768px)",
-  lg: "@media screen and (min-width: 992px)",
-  xl: "@media screen and (min-width: 1200px)"
+  xs: '@media screen and (min-width: 0px)',
+  sm: '@media screen and (min-width: 768px)',
+  md: '@media screen and (min-width: 960px)',
+  lg: '@media screen and (min-width: 1280px)',
+  xl: '@media screen and (min-width: 1900px)',
 };
 
 export default DEVICEQUERRY;


### PR DESCRIPTION
## Description

Modified max-width media queries, I had the major issue that I couldn't differentiate between LG and XL screens, causing problems to query between those.

I would recommend that we include a way of changing these dynamically by theme props, allowing users to even add furthermore screens types, etc. See [Media query issue](https://github.com/proksh/atomize/issues/31)

## How Has This Been Tested?
- Tested that changes allow you to detect displays for mobile, tablet, LG, and XL desktop screens.
- This has been tested into some work projects I'm in that are in production with decent userbase, allowing me to create responsive websites for most devices.

## Screenshots:

Example code:
````
class App extends Component {
  render() {
    return (
      <StyletronProvider value={engine} debug={debug} debugAfterHydration>
        <ThemeProvider theme={theme}>
          <StyleReset />

          <Div
            textColor="green"
            minH="100vh"
            w="100vw"
            d="flex"
            flexDir="column"
            justify="center"
            align="center"
            textSize="display2"
            fontFamily="secondary"
            d={{ xs: 'flex', md: 'none' }}
            textWeight="500"
            p={{ x: '1rem', y: '4rem' }}
          >
            XS Display Message
          </Div>
          <Div
            textColor="red"
            minH="100vh"
            w="100vw"
            d="flex"
            flexDir="column"
            justify="center"
            align="center"
            textSize="display2"
            fontFamily="secondary"
            d={{ lg: 'none', md: 'flex' }}
            textWeight="500"
            p={{ x: '1rem', y: '4rem' }}
          >
            MD Display Message
          </Div>
          <Div
            textColor="blue"
            minH="100vh"
            w="100vw"
            d="flex"
            flexDir="column"
            justify="center"
            align="center"
            textSize="display2"
            fontFamily="secondary"
            d={{ lg: 'flex', xl: 'none' }}
            textWeight="500"
            p={{ x: '1rem', y: '4rem' }}
          >
            LG Display Message
          </Div>
          <Div
            textColor="purple"
            minH="100vh"
            w="100vw"
            d="flex"
            flexDir="column"
            justify="center"
            align="center"
            textSize="display2"
            fontFamily="secondary"
            d={{ lg: 'none', xl: 'flex' }}
            textWeight="500"
            p={{ x: '1rem', y: '4rem' }}
          >
            XL Display Message
          </Div>
        </ThemeProvider>
      </StyletronProvider>
    );
  }
}

````
### Visual state with changes 

![image](https://user-images.githubusercontent.com/41529438/80929452-297ff680-8d7a-11ea-854e-43fcf0599992.png)
![image](https://user-images.githubusercontent.com/41529438/80929463-40264d80-8d7a-11ea-90c8-1ead6938f3e2.png)
![image](https://user-images.githubusercontent.com/41529438/80929474-53d1b400-8d7a-11ea-8161-12be1ee4ce0f.png)
![image](https://user-images.githubusercontent.com/41529438/80929490-677d1a80-8d7a-11ea-8d25-9c8044f6d75b.png)

### Visual state without changes 
![image](https://user-images.githubusercontent.com/41529438/80929651-c1321480-8d7b-11ea-8ce8-e3054d200c72.png)

![image](https://user-images.githubusercontent.com/41529438/80929668-ec1c6880-8d7b-11ea-96c7-4fdfe5388353.png)

![image](https://user-images.githubusercontent.com/41529438/80929714-37367b80-8d7c-11ea-93df-5692b46957a0.png)

![image](https://user-images.githubusercontent.com/41529438/80929729-4d443c00-8d7c-11ea-9fca-18e2076603d5.png)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Risks

This could change how other websites are shown, especially if they had LG and XL tags that were undetected before. 
